### PR TITLE
implement rate limiter middleware

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -4,11 +4,13 @@ import { matchRouter } from "./routes/match.routes.js";
 import { errorMiddleware } from "./middlewares/errors.middleware.js";
 import cors from "cors";
 import { contrabandRouter } from "./routes/contraband.routes.js";
+import { rateLimiter } from "./middlewares/rateLimiter.middleware.js";
 
 const app = express();
 
 app.use(express.json());
 app.use(cors());
+app.use(rateLimiter);
 app.use("/v1/match", matchRouter);
 app.use("/v1/contraband", contrabandRouter);
 

--- a/backend/middlewares/rateLimiter.middleware.ts
+++ b/backend/middlewares/rateLimiter.middleware.ts
@@ -1,0 +1,68 @@
+import type { NextFunction, Request, Response } from "express";
+import { prisma } from "../prisma/client.js";
+
+export async function rateLimiter(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const WINDOW_SIZE_IN_MINUTES = 15 * 60 * 1000; // 15 minutes
+  const WINDOW_REQUEST_LIMIT = 100;
+
+  const key = req.ip ?? "";
+
+  const rateLimit = await prisma.rateLimiter.findUnique({
+    where: {
+      id: key,
+    },
+  });
+
+  // If there's no rate limit for the IP, it's the first request
+  if (!rateLimit) {
+    await prisma.rateLimiter.create({
+      data: {
+        id: key,
+        requests: 1,
+        windowStart: new Date(),
+      },
+    });
+    return next();
+  }
+
+  const currentTime = new Date().getTime();
+  const timeDifference = currentTime - rateLimit.windowStart.getTime();
+
+  // If window expired, reset the count and window start time
+  if (timeDifference > WINDOW_SIZE_IN_MINUTES) {
+    await prisma.rateLimiter.update({
+      where: {
+        id: key,
+      },
+      data: {
+        requests: 1,
+        windowStart: new Date(),
+      },
+    });
+    return next();
+  }
+
+  if (rateLimit.requests >= WINDOW_REQUEST_LIMIT) {
+    return res
+      .status(420)
+      .json({ message: "Too many requests. Please try again later." });
+  }
+
+  // Increment the request count
+  await prisma.rateLimiter.update({
+    where: {
+      id: key,
+    },
+    data: {
+      requests: {
+        increment: 1,
+      },
+    },
+  });
+
+  next();
+}

--- a/backend/prisma/client.ts
+++ b/backend/prisma/client.ts
@@ -1,0 +1,8 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const prisma = new PrismaClient({ adapter });

--- a/backend/prisma/migrations/20260723004817_rate_limiter/migration.sql
+++ b/backend/prisma/migrations/20260723004817_rate_limiter/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "rate_limit" (
+    "id" TEXT NOT NULL,
+    "requests" INTEGER NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rate_limit_pkey" PRIMARY KEY ("id")
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -58,3 +58,11 @@ enum Resource {
     cheese
     chicken
 }
+
+model RateLimiter {
+    id          String   @id
+    requests    Int
+    windowStart DateTime
+
+    @@map("rate_limit")
+}

--- a/backend/services/contraband.service.ts
+++ b/backend/services/contraband.service.ts
@@ -1,11 +1,4 @@
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@prisma/client";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
-
-export const prisma = new PrismaClient({ adapter });
+import { prisma } from "../prisma/client.js";
 
 export const getContrabands = async () => {
   const contrabands = await prisma.contraband.findMany();

--- a/backend/services/match.service.ts
+++ b/backend/services/match.service.ts
@@ -1,4 +1,3 @@
-import { PrismaPg } from "@prisma/adapter-pg";
 import {
   GOODS_SCORES,
   KINGS_BONUS,
@@ -6,20 +5,10 @@ import {
   QUEENS_BONUS,
 } from "../constants.js";
 import type { KingQueenResourceName, Player, PlayerScore } from "../types.js";
-import { PrismaClient, type Match } from "@prisma/client";
 import type { MatchWithPlayers } from "./types.js";
 import { AppError } from "../utils/AppError.js";
-import {
-  getPageOffset,
-  ITEMS_PER_PAGE,
-  parseStringToDate,
-} from "../utils/utils.js";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
-
-export const prisma = new PrismaClient({ adapter });
+import { getPageOffset, ITEMS_PER_PAGE } from "../utils/utils.js";
+import { prisma } from "../prisma/client.js";
 
 export const calculateMatchScore = async (players: Player[]) => {
   const matchPlayers = await calculateGoodsScore(players);


### PR DESCRIPTION
Implement rate limiter middleware

100 requests each 15 minutes per IP

Add a new RateLimiter table to store requests for each IP and return `429` too many requests if the limit is exceeded in the 15 minutes window.

Bonus: centralize prisma client in a file